### PR TITLE
Remove GeoClueManager._clients

### DIFF
--- a/lib/geoclue.dart
+++ b/lib/geoclue.dart
@@ -28,6 +28,5 @@
 library geoclue;
 
 export 'src/accuracy_level.dart';
-export 'src/client.dart';
+export 'src/geoclue.dart';
 export 'src/location.dart';
-export 'src/manager.dart';

--- a/lib/src/client.dart
+++ b/lib/src/client.dart
@@ -1,11 +1,4 @@
-import 'dart:async';
-
-import 'package:dbus/dbus.dart';
-
-import 'accuracy_level.dart';
-import 'geoclue.dart';
-import 'location.dart';
-import 'util.dart';
+part of 'geoclue.dart';
 
 /// Retrieves location information and receives location update events from the
 /// the GeoClue service.

--- a/lib/src/constants.dart
+++ b/lib/src/constants.dart
@@ -1,0 +1,4 @@
+const kBus = 'org.freedesktop.GeoClue2';
+const kClient = 'org.freedesktop.GeoClue2.Client';
+const kLocation = 'org.freedesktop.GeoClue2.Location';
+const kManager = 'org.freedesktop.GeoClue2.Manager';

--- a/lib/src/geoclue.dart
+++ b/lib/src/geoclue.dart
@@ -1,4 +1,12 @@
-const kBus = 'org.freedesktop.GeoClue2';
-const kClient = 'org.freedesktop.GeoClue2.Client';
-const kLocation = 'org.freedesktop.GeoClue2.Location';
-const kManager = 'org.freedesktop.GeoClue2.Manager';
+import 'dart:async';
+
+import 'package:dbus/dbus.dart';
+import 'package:meta/meta.dart';
+
+import 'accuracy_level.dart';
+import 'constants.dart';
+import 'location.dart';
+import 'util.dart';
+
+part 'client.dart';
+part 'manager.dart';

--- a/lib/src/manager.dart
+++ b/lib/src/manager.dart
@@ -1,12 +1,4 @@
-import 'dart:async';
-
-import 'package:dbus/dbus.dart';
-import 'package:meta/meta.dart';
-
-import 'accuracy_level.dart';
-import 'client.dart';
-import 'geoclue.dart';
-import 'util.dart';
+part of 'geoclue.dart';
 
 /// The GeoClue service manager
 class GeoClueManager {
@@ -27,7 +19,6 @@ class GeoClueManager {
   final DBusRemoteObject _object;
   final _properties = <String, DBusValue>{};
   final _propertyController = StreamController<List<String>>.broadcast();
-  final _clients = <GeoClueClient, DBusObjectPath>{};
   StreamSubscription? _propertySubscription;
 
   /// Whether service is currently is use by any application.
@@ -80,11 +71,9 @@ class GeoClueManager {
   }
 
   GeoClueClient _buildClient(DBusObjectPath path) {
-    final client = GeoClueClient(
+    return GeoClueClient(
       DBusRemoteObject(_object.client, name: kBus, path: path),
     );
-    _clients[client] = path;
-    return client;
   }
 
   /// Use this method to explicitly destroy a client, created using [getClient]
@@ -95,9 +84,7 @@ class GeoClueManager {
   /// for communicating with Geoclue (which is implicit on client process
   /// termination).
   Future<void> deleteClient(GeoClueClient client) {
-    final path = _clients.remove(client);
-    assert(path != null);
-    return _object.callMethod(kManager, 'DeleteClient', [path!],
+    return _object.callMethod(kManager, 'DeleteClient', [client._object.path],
         replySignature: DBusSignature(''));
   }
 

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:dbus/dbus.dart';
 import 'package:geoclue/geoclue.dart';
-import 'package:geoclue/src/geoclue.dart';
+import 'package:geoclue/src/constants.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';

--- a/test/manager_test.dart
+++ b/test/manager_test.dart
@@ -2,7 +2,7 @@ import 'dart:async';
 
 import 'package:dbus/dbus.dart';
 import 'package:geoclue/geoclue.dart';
-import 'package:geoclue/src/geoclue.dart';
+import 'package:geoclue/src/constants.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Make use of the 'part (of)' directive to be able to access clients'
internal remote objects and paths from the manager.