### PR TITLE
Make Client.location an ordinary property

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -9,7 +9,7 @@ Future<void> main() async {
   await client.start();
 
   print('Available accuracy: ${manager.availableAccuracyLevel.name}');
-  print('Last known location: ${await client.getLocation() ?? 'unknown'}');
+  print('Last known location: ${client.location ?? 'unknown'}');
   print('Waiting 10s for location updates...');
   client.locationUpdated
       .timeout(const Duration(seconds: 10), onTimeout: (_) => manager.close())

--- a/test/client_test.dart
+++ b/test/client_test.dart
@@ -32,7 +32,7 @@ void main() {
     final object = createMockRemoteObject();
 
     final client = GeoClueClient(object);
-    expect(await client.getLocation(), isNull);
+    expect(client.location, isNull);
   });
 
   test('unknown location', () async {
@@ -45,7 +45,7 @@ void main() {
     final client = GeoClueClient(object);
     await client.start();
 
-    expect(await client.getLocation(), isNull);
+    expect(client.location, isNull);
   });
 
   test('location', () async {
@@ -75,7 +75,7 @@ void main() {
 
     // init
     const l1 = GeoClueLocation(accuracy: 0.1, latitude: 1.2, longitude: 2.3);
-    expect(await client.getLocation(), equals(l1));
+    expect(client.location, equals(l1));
 
     // changed
     const l2 = GeoClueLocation(accuracy: 4.5, latitude: 5.6, longitude: 6.7);
@@ -86,7 +86,7 @@ void main() {
       expectAsync1((value) => expect(value, equals(l2)), count: 1),
     );
     await expectLater(client.propertiesChanged, emits(['Location']));
-    expect(await client.getLocation(), equals(l2));
+    expect(client.location, equals(l2));
   });
 
   test('is active', () async {


### PR DESCRIPTION
This is more convenient to use, reflects the GeoClue D-Bus API, and
sort of hides the detail that the location object is asynchronously
built under the hood.