### PR TITLE
ci: remove repository CLA check

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   analyzer:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: dart:stable
     steps:
@@ -18,7 +18,7 @@ jobs:
       - run: dart analyze --fatal-infos .
 
   format:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: dart:stable
     steps:
@@ -27,7 +27,7 @@ jobs:
       - run: dart format --set-exit-if-changed .
 
   pub:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: dart:stable
     steps:

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -1,9 +1,0 @@
-name: CLA
-on: [pull_request_target]
-
-jobs:
-  check:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check if CLA signed
-        uses: canonical/has-signed-canonical-cla@v1

--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build-runner:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: dart:stable
     steps:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   coverage:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
     - uses: subosito/flutter-action@v2
@@ -20,7 +20,7 @@ jobs:
         token: ${{secrets.CODECOV_TOKEN}}
 
   run:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container:
       image: dart:stable
     steps:


### PR DESCRIPTION
## Summary

Remove the dedicated repository-level CLA workflow now that CLA checking is provided by the organization-wide GitHub Action.

## Validation

- Confirmed no remaining CLA action references under `.github/workflows`
- Confirmed no workflow dependencies reference the removed check
- Ran `git diff --check`